### PR TITLE
Return Lease and EStop/"Motor Power Authority" in shutdown hook

### DIFF
--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -484,8 +484,16 @@ class SpotROS():
 
     def shutdown(self):
         rospy.loginfo("Shutting down ROS driver for Spot")
-        self.spot_wrapper.sit()
+        success, msg = self.spot_wrapper.safe_power_off()
+        if not success:
+            rospy.logerr(f"Unable to perform safe power off: {msg}")
+        success, msg = self.spot_wrapper.release()
+        if not success:
+            rospy.logger(f"Unable to release SpotWrapper: {msg}")
+        # TODO: This sleep might not be necessary anymore. safe_power_off (which needs to be
+        # updated to safe_power_off_motors) should block until completion.
         time.sleep(0.5)
+        # TODO: Why are we immediately exiting? Isn't this method part of a graceful shutdown?
         os._exit(1)
 
     def setupPubSub(self):

--- a/spot_driver/src/spot_driver/spot_ros.py
+++ b/spot_driver/src/spot_driver/spot_ros.py
@@ -636,12 +636,12 @@ class SpotROS():
                     success, msg = self.spot_wrapper.claim()
                     if not success:
                         rospy.logerr('Unable to claim spot: ' + msg)
-                        os._exit(1)
+                        rospy.signal_shutdown("Unable to claim spot: graceful shutdown")
                     if self.auto_power_on:
                         success, msg = self.spot_wrapper.power_on()
                         if not success:
                             rospy.logerr('Unable to power on: ' + msg)
-                            os._exit(1)
+                            rospy.signal_shutdown("Unable to power on: graceful shutdown")
                         if self.auto_stand:
                             self.spot_wrapper.stand()
             except Exception as e:


### PR DESCRIPTION
This PR reworks the spot_driver shutdown hook to address issues with the robot not starting up. The spot_driver code would often emit an error containing one or more of `LeaseUseError`, `EstopResponseError`, or `MotorsOnError` while the Spot's front lights would slowly blink green in a "lockout mode".

The underlying problem appears to be that the estop client/endpoint from the previous session is still live, which prevents a new endpoint from being registered (although the [docs](https://dev.bostondynamics.com/docs/concepts/estop_service) suggest that multiple estop endpoints can exist at the same time and the code should forcefully take ownership of the estop, see below).

https://github.com/boston-dynamics/spot-sdk/blob/208c885d99813d02b4d78940289cf1c9d0279674/python/bosdyn-client/src/bosdyn/client/estop.py#L292-L301

## Changes

The new shutdown hook attempts to power off the robot's motors and release the Lease and E-Stop before exiting. The 6 second sleep was found via trial and error to allow enough time for the robot to sit properly before releasing the estop (which cuts motor power immediately) and for the robot's internal computer to register that the motors are powered off. When the node is fully shut down, Spot's front lights return to the moving rainbow lights [(reference)](https://support.bostondynamics.com/s/article/Spot-anatomy#statusLights).

Various immediate exits (`os._exit(1)`) are removed to allow proper cleanup and shutdown of the node.

[Video (links to slack)](https://amrl.slack.com/files/U02PA0P8G2J/F04RBD9L690/20230226_142330_1.mp4)

## Caveats

The robot **_can_** still enter the lockout mode: I think I was able to do it by killing the node using `rosnode kill` and then immediately trying to start the node back up again. Under normal usage (e.g. SIGINT) this doesn't happen and I'm going to assume users won't try to stress-test it.

I didn't test behavior after network disconnects, but I assume the robot will sit down and may enter the lockout mode after the robot detects that the connection was dropped.

## 
P.S. It turns out the heuristic of "wait 10 seconds until trying to start the robot again" was actually well founded -- the driver code specifies a default E-Stop expiration of 9 seconds. This PR actually isn't technically necessary if the user waits the full 9 seconds before trying again, but the new shutdown hook seems to more closely resemble the Boston Dynamics controller stack and saves 3 seconds.
https://github.com/ut-amrl/spot_ros/blob/523722f30e081542b71d2382f9dc2b7901a756d8/spot_driver/src/spot_driver/spot_wrapper.py#L425